### PR TITLE
GHA: DB merge: fix --rebuild flow after refactor

### DIFF
--- a/scripts/db_merge.sh
+++ b/scripts/db_merge.sh
@@ -18,11 +18,14 @@ SCRIPT_DIR=$(dirname $(realpath "$0"))
 IMAGE_DB_DIR="$SCRIPT_DIR/../kernel-image-db"
 KPWN_DB_DIR="$SCRIPT_DIR/../kpwn_db"
 
+mkdir -p db
+rm -rf db/*
+
 if [ "$1" == "--rebuild" ]; then
     echo -n > db_releases.txt
 else
-    gcloud storage cp gs://kernel-research/pwnkit/db/kernelctf.kpwn db.kpwn; echo
-    "$KPWN_DB_DIR/kpwn_db.py" -i db.kpwn --list-targets | grep kernelctf | sed "s/kernelctf\///" > db_releases.txt
+    gcloud storage cp gs://kernel-research/pwnkit/db/kernelctf.kpwn db/_original.kpwn; echo
+    "$KPWN_DB_DIR/kpwn_db.py" -i db/_original.kpwn --list-targets | grep kernelctf | sed "s/kernelctf\///" > db_releases.txt
 fi
 
 gcloud storage ls gs://kernel-research/pwnkit/db/kernelctf/*.kpwn > gcs_releases.txt
@@ -34,10 +37,7 @@ echo "The following files were not merged into the DB yet: "
 cat missing_db_releases.txt
 echo
 
-mkdir -p db
-rm -rf db/*
 cat missing_db_releases.txt | gsutil -m cp -I ./db
-cp db.kpwn db/_original.kpwn
 
 "$KPWN_DB_DIR/kpwn_db.py" -i "db/*.kpwn" -o kernelctf.kpwn
 "$KPWN_DB_DIR/kpwn_db.py" -i kernelctf.kpwn -o kernelctf.json


### PR DESCRIPTION
db.kpwn did not exist in case of --rebuild which caused failure, so use db/_original.kpwn instead which works both if it exists or not