### PR TITLE
libxdk: Rename GetNumPages() to GetKernelPageCount()

### DIFF
--- a/docs/kxdb_file_format.txt
+++ b/docs/kxdb_file_format.txt
@@ -59,7 +59,7 @@ targets[seekable_varsize]          # sorted by (distro,release_name)
       ret_offset (uint)
       shift_amount (uint)
   struct_layout_indices (varsize_ints) # seekable, skippable
-  num_pages (u2)
+  kernel_page_count (u2)
 struct_layouts[seekable_varsize]
   struct_meta_idx (uint)
   sizeof_structure (uint)

--- a/kxdb_tool/converter/image_db_target.py
+++ b/kxdb_tool/converter/image_db_target.py
@@ -91,7 +91,7 @@ class ImageDbTarget:
   def get_structs(self):
     return self.from_json(self.STRUCTS_JSON, Structs)
 
-  def get_num_pages(self):
+  def get_kernel_page_count(self):
     return int(self.read_file(self.KERNEL_PAGES_TXT).strip())
 
   def process_symbols(self, config=None):
@@ -131,7 +131,7 @@ class ImageDbTarget:
     rop_actions = self.process_rop_actions(config)
     stack_pivots = self.get_stack_pivots()
     structs = self.process_structs(config, allow_missing)
-    num_pages = self.get_num_pages()
+    kernel_page_count = self.get_kernel_page_count()
     return Target(distro=self.distro, release_name=self.release_name, version=version,
                   symbols=symbols, rop_actions=rop_actions, stack_pivots=stack_pivots,
-                  structs=structs, num_pages=num_pages)
+                  structs=structs, kernel_page_count=kernel_page_count)

--- a/kxdb_tool/converter/kxdb_reader.py
+++ b/kxdb_tool/converter/kxdb_reader.py
@@ -70,12 +70,12 @@ class KxdbReader:
       structs = self.struct_reader.read_target(r_root)
 
       if minor_ver >= 2:
-        num_pages = r_root.u2()
+        kernel_page_count = r_root.u2()
       else:
-        num_pages = 0
+        kernel_page_count = 0
 
       target = Target(distro, release_name, version,
-                      symbols, rop_actions, stack_pivots, structs, num_pages)
+                      symbols, rop_actions, stack_pivots, structs, kernel_page_count)
 
       targets.append(target)
 

--- a/kxdb_tool/converter/kxdb_writer.py
+++ b/kxdb_tool/converter/kxdb_writer.py
@@ -64,7 +64,7 @@ class KxdbWriter:
         self.stack_pivot_writer.write_target(wr_target, target)
         self.struct_writer.write_target(wr_target, target)
 
-        wr_target.u2(target.num_pages)
+        wr_target.u2(target.kernel_page_count)
 
     # struct layouts
     with sections.add(SECTION_STRUCT_LAYOUTS) as wr:

--- a/kxdb_tool/data_model/db.py
+++ b/kxdb_tool/data_model/db.py
@@ -29,7 +29,7 @@ class Target():
   rop_actions: Optional[RopActions]
   stack_pivots: Optional[Pivots]
   structs: Optional[Structs]
-  num_pages: int
+  kernel_page_count: int
 
   def __str__(self):
     return f"{self.distro}/{self.release_name}"

--- a/kxdb_tool/test/expected_results/lts_6_1_36_db.json
+++ b/kxdb_tool/test/expected_results/lts_6_1_36_db.json
@@ -408,7 +408,7 @@
                     "meta_idx": 4
                 }
             },
-            "num_pages": 41
+            "kernel_page_count": 41
         }
     ]
 }

--- a/kxdb_tool/test/expected_results/lts_6_1_38_db.json
+++ b/kxdb_tool/test/expected_results/lts_6_1_38_db.json
@@ -259,7 +259,7 @@
                 ]
             },
             "structs": {},
-            "num_pages": 41
+            "kernel_page_count": 41
         }
     ]
 }

--- a/kxdb_tool/test/test_kxdb_writer.py
+++ b/kxdb_tool/test/test_kxdb_writer.py
@@ -134,7 +134,7 @@ class KxdbWriterTests(unittest.TestCase):
           b"\0" +                      # t[0].pivots.pop_rsps.count
           b"\0" +                      # t[0].pivots.stack_shifts.count
           b"\0" +                      # t[0].struct_layout_indices
-          b"\x29\x00")                 # t[0].num_pages
+          b"\x29\x00")                 # t[0].kernel_page_count
 
 
     self.expect_smart(

--- a/libxdk/include/xdk/target/Target.h
+++ b/libxdk/include/xdk/target/Target.h
@@ -121,7 +121,7 @@ protected:
     std::map<std::string, std::vector<RopItem>> rop_actions;
     std::map<std::string, Struct> structs;
     Pivots pivots;
-    uint64_t num_pages_ = 0;
+    uint64_t page_count_ = 0;
 
 public:
     /**
@@ -164,7 +164,7 @@ public:
      * @return The number of runtime kernel pages.
      * @throws ExpKitError if the number of runtime kernel pages is not available.
      */
-    uint64_t GetNumPages() const;
+    uint64_t GetKernelPageCount() const;
 
     /**
      * @brief Add a symbol to the target.
@@ -204,7 +204,7 @@ public:
     /**
      * @brief Sets the number of runtime kernel pages for the target.
      */
-    void SetNumPages(uint64_t num_pages);
+    void SetKernelPageCount(uint64_t page_count_);
 
     void Merge(const Target& src);
 

--- a/libxdk/target/KxdbParser.cpp
+++ b/libxdk/target/KxdbParser.cpp
@@ -132,9 +132,9 @@ vector<Target> KxdbParser::ParseTargets(
     ParseStructs(target);
 
     if (version_minor_ >= 2) {
-      target.SetNumPages(ReadU16());
+      target.SetKernelPageCount(ReadU16());
     } else {
-      DebugLog("version_minor_=%u, not setting num_pages", version_minor_);
+      DebugLog("version_minor_=%u, not setting kernel page count", version_minor_);
     }
 
     result.push_back(target);

--- a/libxdk/target/Target.cpp
+++ b/libxdk/target/Target.cpp
@@ -57,11 +57,11 @@ uint32_t Target::GetSymbolOffset(std::string symbol_name) {
   return it->second;
 }
 
-uint64_t Target::GetNumPages() const {
-  if (num_pages_ == 0) {
-    throw ExpKitError("number of pages is not available, rebuild the database to use this feature");
+uint64_t Target::GetKernelPageCount() const {
+  if (page_count_ == 0) {
+    throw ExpKitError("Kernel page count is not available, rebuild the database to use this feature");
   }
-  return num_pages_;
+  return page_count_;
 }
 
 Target::Target(const std::string& distro,
@@ -91,8 +91,8 @@ void Target::SetPivots(const Pivots& pivots) {
   this->pivots = pivots;
 }
 
-void Target::SetNumPages(uint64_t num_pages) {
-  num_pages_ = num_pages;
+void Target::SetKernelPageCount(uint64_t page_count) {
+  page_count_ = page_count;
 }
 
 void Target::Merge(const Target& src) {
@@ -124,8 +124,8 @@ void Target::Merge(const Target& src) {
     }
   }
 
-  if (src.num_pages_ != 0) {
-    num_pages_ = src.num_pages_;
+  if (src.page_count_ != 0) {
+    page_count_ = src.page_count_;
   }
 }
 

--- a/libxdk/test/tests/TargetDbTests.h
+++ b/libxdk/test/tests/TargetDbTests.h
@@ -161,7 +161,7 @@ struct TargetDbTests: TestSuite {
         Target st("kernelctf", "lts-6.1.81");
         st.AddSymbol("new_symbol", 0x1234);
         st.AddStruct("new_struct", 80, { { "field1", 0x10, 8 }, { "field2", 0x20, 8 } });
-        st.SetNumPages(0x4141);
+        st.SetKernelPageCount(0x4141);
         db.AddTarget(st);
 
         auto target = db.GetTarget(lts_6181_version);
@@ -171,7 +171,7 @@ struct TargetDbTests: TestSuite {
         ASSERT_EQ(0x1234, target.GetSymbolOffset("new_symbol"));
         ASSERT_EQ(0x20, target.GetStruct("new_struct").fields.at("field2").offset);
 
-        ASSERT_EQ(0x4141, target.GetNumPages());
+        ASSERT_EQ(0x4141, target.GetKernelPageCount());
     }
 
     TEST_METHOD(staticDbWorks, "TargetDb can work with only targets without a db") {

--- a/libxdk/test/tests/UtilsRuntimeTests.h
+++ b/libxdk/test/tests/UtilsRuntimeTests.h
@@ -31,11 +31,11 @@ public:
     void init() { xdk_ = &env->GetXdkDevice(); }
 
     TEST_METHOD(leaksKaslrBase, "leaks KASLR base") {
-        uint64_t num_pages = env->GetTarget().GetNumPages();
+        uint64_t page_count = env->GetTarget().GetKernelPageCount();
         uint64_t expected = xdk_->KaslrLeak();
         int wrong = 0;
         for (int i = 0; i < 100; i++) {
-            uint64_t actual = leak_kaslr_base(num_pages, /* samples = */ 100, /* trials = */ 3);
+            uint64_t actual = leak_kaslr_base(page_count, /* samples = */ 100, /* trials = */ 3);
             if (actual != expected) {
                 wrong++;
             }


### PR DESCRIPTION
Rename the method GetNumPages() on the target class to GetKernelPageCount(). Also rename the corresponding field in the KXDB. The new name highlights that the page count belongs to the kernel image.